### PR TITLE
dim_z_category and video sampling fixes 

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -99,7 +99,7 @@ class VideoDataset(torch.utils.data.Dataset):
         video_len = longer // shorter
 
         # videos can be of various length, we randomly sample sub-sequences
-        if video_len > self.video_length * self.every_nth:
+        if video_len >= self.video_length * self.every_nth:
             needed = self.every_nth * (self.video_length - 1)
             gap = video_len - needed
             start = 0 if gap == 0 else np.random.randint(0, gap, 1)[0]

--- a/src/models.py
+++ b/src/models.py
@@ -231,6 +231,9 @@ class VideoGenerator(nn.Module):
     def sample_z_categ(self, num_samples, video_len):
         video_len = video_len if video_len is not None else self.video_length
 
+        if self.dim_z_category <= 0:
+            return None, np.zeros(num_samples)
+
         classes_to_generate = np.random.randint(self.dim_z_category, size=num_samples)
         one_hot = np.zeros((num_samples, self.dim_z_category), dtype=np.float32)
         one_hot[np.arange(num_samples), classes_to_generate] = 1
@@ -258,7 +261,10 @@ class VideoGenerator(nn.Module):
         z_category, z_category_labels = self.sample_z_categ(num_samples, video_len)
         z_motion = self.sample_z_m(num_samples, video_len)
 
-        z = torch.cat([z_content, z_category, z_motion], dim=1)
+        if z_category is not None:
+            z = torch.cat([z_content, z_category, z_motion], dim=1)
+        else:
+            z = torch.cat([z_content, z_motion], dim=1)
 
         return z, z_category_labels
 


### PR DESCRIPTION
Hi,
I have found some small issues and would like to provide fixes on:

**1) src/data.py - VideoDataset**
Sampling 16-frame sequence, taking every 2nd frame from shapes dataset cannot be done due to bug in data.py:102. With video_len = 32, self.video_length=16, self.every_nth=2 there are enough frames to sample video with stride 2. 
In current version, frames from 0 to 15 are sampled, resulting into learning half of the full shape motion (from border to center).

**2) src/models.py - VideoGenerator - sample_z_video**
As suggested in #16, launching training with dim_z_category=0 results into crash. 

**Output:**
```
{'--batches': '100000',
  "please use transforms.Resize instead.")
 '--dim_z_category': '0',
 '--dim_z_content': '50',
 '--dim_z_motion': '10',
 '--every_nth': '2',
 '--image_batch': '32',
 '--image_dataset': '',
 '--image_discriminator': 'PatchImageDiscriminator',
 '--image_size': '64',
 '--n_channels': '3',
 '--noise_sigma': '0.1',
 '--print_every': '100',
 '--use_categories': False,
 '--use_infogan': False,
 '--use_noise': True,
 '--video_batch': '32',
 '--video_discriminator': 'PatchVideoDiscriminator',
 '--video_length': '16',
 '<dataset>': '../data/shapes',
 '<log_folder>': '../logs/shapes'}
Total number of frames 256000
Traceback (most recent call last):
  File "/home/vlad/PycharmProjects/temp/mocogan/src/train.py", line 130, in <module>
    trainer.train(generator, image_discriminator, video_discriminator)
  File "/home/vlad/PycharmProjects/temp/mocogan/src/trainers.py", line 262, in train
    self.image_batch_size, use_categories=False)
  File "/home/vlad/PycharmProjects/temp/mocogan/src/trainers.py", line 165, in train_discriminator
    fake_batch, generated_categories = sample_fake(batch_size)
  File "/home/vlad/PycharmProjects/temp/mocogan/src/trainers.py", line 236, in sample_fake_image_batch
    return generator.sample_images(batch_size)
  File "/home/vlad/PycharmProjects/temp/mocogan/src/models.py", line 282, in sample_images
    z, z_category_labels = self.sample_z_video(num_samples * self.video_length * 2)
  File "/home/vlad/PycharmProjects/temp/mocogan/src/models.py", line 258, in sample_z_video
    z_category, z_category_labels = self.sample_z_categ(num_samples, video_len)
  File "/home/vlad/PycharmProjects/temp/mocogan/src/models.py", line 234, in sample_z_categ
    classes_to_generate = np.random.randint(self.dim_z_category, size=num_samples)
  File "mtrand.pyx", line 993, in mtrand.RandomState.randint
ValueError: low >= high

Process finished with exit code 1 
```

**Fix**: not using z_category in sampling in src/models.py:261

Hope it was helpful
Regards,
Vlad